### PR TITLE
Fix local unwind handling on Win64 AArch64

### DIFF
--- a/compiler/aarch64/cgcpu.pas
+++ b/compiler/aarch64/cgcpu.pas
@@ -100,6 +100,7 @@ interface
         procedure g_proc_exit(list: TAsmList; parasize: longint; nostackframe: boolean);override;
         procedure g_maybe_got_init(list: TAsmList); override;
         procedure g_restore_registers(list: TAsmList);override;
+        procedure g_local_unwind(list: TAsmList; l: TAsmLabel);override;
         procedure g_save_registers(list: TAsmList);override;
         procedure g_concatcopy(list: TAsmList; const source, dest: treference; len: tcgint);override;
         procedure g_adjust_self_value(list: TAsmList; procdef: tprocdef; ioffset: tcgint);override;
@@ -2041,6 +2042,38 @@ implementation
     procedure tcgaarch64.g_restore_registers(list:TAsmList);
       begin
         { done in g_proc_exit }
+      end;
+
+
+    procedure tcgaarch64.g_local_unwind(list: TAsmList; l: TAsmLabel);
+      var
+        para1, para2: tcgpara;
+        href: treference;
+        pd: tprocdef;
+        framereg: tregister;
+      begin
+        if target_info.system<>system_aarch64_win64 then
+          begin
+            inherited g_local_unwind(list,l);
+            exit;
+          end;
+        pd:=search_system_proc('_fpc_local_unwind');
+        para1.init;
+        para2.init;
+        paramanager.getcgtempparaloc(list,pd,1,para1);
+        paramanager.getcgtempparaloc(list,pd,2,para2);
+        reference_reset_symbol(href,l,0,1,[]);
+        if pi_no_framepointer_needed in current_procinfo.flags then
+          framereg:=NR_STACK_POINTER_REG
+        else
+          framereg:=NR_FP;
+        a_load_reg_cgpara(list,OS_ADDR,framereg,para1);
+        a_loadaddr_ref_cgpara(list,href,para2);
+        paramanager.freecgpara(list,para2);
+        paramanager.freecgpara(list,para1);
+        g_call(list,'_FPC_local_unwind');
+        para2.done;
+        para1.done;
       end;
 
 

--- a/compiler/options.pas
+++ b/compiler/options.pas
@@ -5742,7 +5742,7 @@ begin
 {$endif not DISABLE_TLS_DIRECTORY}
 
 {$ifndef DISABLE_WIN64_SEH}
-    if target_info.system=system_x86_64_win64 then
+    if target_info.system in [system_x86_64_win64,system_aarch64_win64] then
       def_system_macro('FPC_USE_WIN64_SEH');
 {$endif DISABLE_WIN64_SEH}
 

--- a/rtl/win64/seh64.inc
+++ b/rtl/win64/seh64.inc
@@ -265,6 +265,11 @@ procedure RtlUnwindEx(
   HistoryTable: PUNWIND_HISTORY_TABLE);
   external 'kernel32.dll' name 'RtlUnwindEx';
 
+procedure RtlRestoreContext(
+  ContextRecord: PContext;
+  ExceptionRecord: PExceptionRecord = nil); stdcall;
+  external 'kernel32.dll' name 'RtlRestoreContext';
+
 
 { FPC specific stuff }
 {$ifdef SYSTEM_USE_WIN_SEH}
@@ -412,6 +417,10 @@ var
   ctx: TContext;
 begin
   RtlUnwindEx(frame,target,nil,nil,@ctx,nil);
+{$if defined(CPUAARCH64)}
+  { On Windows ARM64 RtlUnwindEx may return instead of transferring control }
+  RtlRestoreContext(@ctx,nil);
+{$endif CPUAARCH64}
 end;
 {$pop}
 


### PR DESCRIPTION
## Summary
- implement g_local_unwind for Win64 AArch64 so local unwinding calls the runtime helper
- ensure finally blocks execute when exiting try/finally on Windows ARM64
- enable Win64 SEH macro for Windows AArch64 so the runtime helper is available
- pass the established frame pointer register to `_FPC_local_unwind` on Windows ARM64 so unwinding resumes correctly after finally blocks
- restore the Windows ARM64 context with `RtlRestoreContext` after calling `RtlUnwindEx` so control reaches the unwind target instead of returning with a corrupted stack

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9404ef0f0832a8fb3faa4da62c2ec